### PR TITLE
Adapt to new spatstat.random package.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,7 +15,7 @@ LazyLoad: yes
 Depends:
     R (>= 3.1.1)
 Imports:
-    spatstat.geom, spatstat.core, smerc, plotrix, abind, pbapply, sp
+    spatstat.geom, spatstat.random, spatstat.core, smerc, plotrix, abind, pbapply, sp
 Suggests: 
     testthat, knitr, rmarkdown
 VignetteBuilder: knitr

--- a/R/Kdest.R
+++ b/R/Kdest.R
@@ -63,7 +63,7 @@ kdest = function(x, case = 2, nsim = 0, level = 0.95, r = NULL,
     #min/max envelope
     out = spatstat.core::envelope(x, kd, case = case, nsim = nsim, 
                              savefuns = TRUE, 
-                             simulate = expression(spatstat.core::rlabel(x, permute = TRUE)), 
+                             simulate = expression(spatstat.random::rlabel(x, permute = TRUE)), 
                              r = r, rmax = rmax, 
                              breaks = breaks, 
                              correction = correction, 


### PR DESCRIPTION
Random generators are being moved from `spatstat.core` to a new package `spatstat.random`.
The proposed changes should hopefully fix the upcoming problem for your package.